### PR TITLE
Fix mobile navbar initialization

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -7,7 +7,7 @@ const { current } = Astro.props;
     <img class="site-logo" src="/assets/jj.png" alt="JJ" />
   </a>
 
-  <button class="burger" aria-label="Abrir menú" aria-expanded="false">☰</button>
+  <button class="burger" aria-label="Abrir menú" aria-expanded="false" type="button">☰</button>
 
   <div class="nav-links">
     <a href="/" class:list={{ selected: current === "home" }}>Inicio</a>
@@ -21,7 +21,14 @@ const { current } = Astro.props;
 <script type="module">
   import { setupNav } from "../scripts/nav.js";
 
-  document.body.classList.add("is-loaded");
-  setupNav();
-</script>
+  const initNav = () => {
+    document.body.classList.add("is-loaded");
+    setupNav();
+  };
 
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initNav, { once: true });
+  } else {
+    initNav();
+  }
+</script>

--- a/src/scripts/nav.js
+++ b/src/scripts/nav.js
@@ -29,7 +29,3 @@ export function setupNav() {
     });
   };
 }
-
-if (typeof window !== 'undefined') {
-  setupNav();
-}


### PR DESCRIPTION
## Summary
- initialize mobile navbar after DOM is ready and ensure button does not submit forms
- simplify nav script to export setup function without auto-running on import

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6175cf2083228887e637cf306bf9)