### PR TITLE
Inline navbar script for reliable mobile menu

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -7,7 +7,7 @@ const { current } = Astro.props;
     <img class="site-logo" src="/assets/jj.png" alt="JJ" />
   </a>
 
-  <button class="burger" aria-label="Abrir menú" aria-expanded="false">☰</button>
+  <button class="burger" aria-label="Abrir menú" aria-expanded="false" type="button">☰</button>
 
   <div class="nav-links">
     <a href="/" class:list={{ selected: current === "home" }}>Inicio</a>
@@ -18,10 +18,47 @@ const { current } = Astro.props;
   </div>
 </nav>
 
-<script type="module">
-  import { setupNav } from "../scripts/nav.js";
+<script is:inline>
+  const setupNav = () => {
+    const navButton = document.querySelector('.burger');
+    const navMenu = document.querySelector('.nav-links');
 
-  document.body.classList.add("is-loaded");
-  setupNav();
+    if (!navButton || !navMenu) return;
+
+    const closeNav = () => {
+      navMenu.classList.remove('open');
+      navButton.setAttribute('aria-expanded', 'false');
+    };
+
+    const toggleNav = () => {
+      const isOpen = navMenu.classList.contains('open');
+
+      navMenu.classList.toggle('open', !isOpen);
+      navButton.setAttribute('aria-expanded', String(!isOpen));
+    };
+
+    navButton.addEventListener('click', toggleNav);
+
+    navMenu.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', closeNav);
+    });
+
+    return () => {
+      navButton.removeEventListener('click', toggleNav);
+      navMenu.querySelectorAll('a').forEach((link) => {
+        link.removeEventListener('click', closeNav);
+      });
+    };
+  };
+
+  const initNav = () => {
+    document.body.classList.add('is-loaded');
+    setupNav();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initNav, { once: true });
+  } else {
+    initNav();
+  }
 </script>
-

--- a/src/scripts/nav.js
+++ b/src/scripts/nav.js
@@ -29,7 +29,3 @@ export function setupNav() {
     });
   };
 }
-
-if (typeof window !== 'undefined') {
-  setupNav();
-}


### PR DESCRIPTION
## Summary
- inline the navbar toggle logic so it ships with every built page
- keep DOM-ready initialization to toggle and close the mobile menu reliably

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6175cf2083228887e637cf306bf9)