### PR TITLE
Add 'Servicios' CTA to homepage and remove duplicated service list

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,41 +22,6 @@ import ContactCTA from "../components/ContactCTA.astro";
       <a class="cta" href="/contacto">Hablemos de tu proyecto</a>
     </section>
 
-    <!-- SERVICIOS -->
-    <section>
-      <h2>Plugins WordPress a medida</h2>
-      <p>
-        Diseño e implemento funcionalidades específicas que complementan tu
-        WordPress actual sin sustituir tu tema ni tus plugins.
-        Código limpio, mantenible y alineado con las buenas prácticas del
-        ecosistema WordPress.
-      </p>
-    </section>
-
-    <section>
-      <h2>Mejoras sobre tu WordPress actual</h2>
-      <p>
-        No necesitas reconstruir tu sitio. Puedo adaptar y ampliar lo que ya
-        tienes para que tu negocio pueda crecer sin fricciones técnicas.
-      </p>
-    </section>
-
-    <section>
-      <h2>Integraciones y automatización</h2>
-      <p>
-        Conexiones con APIs externas, CRMs y plataformas inmobiliarias como
-        Pisos.com, sincronización de datos y automatización de procesos.
-      </p>
-    </section>
-
-    <section>
-      <h2>Rendimiento y seguridad</h2>
-      <p>
-        Optimización WPO, estabilización técnica, configuraciones CSP,
-        mitigación de vulnerabilidades y mejoras orientadas a la fiabilidad.
-      </p>
-    </section>
-
     <!-- POR QUÉ -->
     <section>
       <h2>Por qué trabajar conmigo</h2>
@@ -77,6 +42,16 @@ import ContactCTA from "../components/ContactCTA.astro";
         Comunicación directa, entregas rápidas y soluciones pensadas para
         durar.
       </p>
+    </section>
+
+    <!-- SERVICIOS -->
+    <section>
+      <h2>Servicios</h2>
+      <p>
+        Descubre cómo puedo ayudarte con desarrollo a medida, mejoras
+        técnicas y soporte continuo para tu WordPress.
+      </p>
+      <a class="cta" href="/servicios">Ver servicios</a>
     </section>
 
     <!-- PLUGINS -->


### PR DESCRIPTION
### Motivation
- The homepage contained a full, detailed list of services that duplicates the content already present on the dedicated services page.
- Replace the duplicated content with a single CTA to keep the homepage concise and direct users to the full `Servicios` page.
- Maintain consistency with other homepage CTAs (plugins, casos, contacto) to improve navigation.

### Description
- Removed multiple detailed service sections from `src/pages/index.astro` and added a single `Servicios` CTA section linking to `/servicios`.
- The new section includes a short descriptive paragraph and a `.cta` link consistent with existing CTAs on the page.
- Only `src/pages/index.astro` was modified in this change.

### Testing
- Started the development server with `npm run dev` and confirmed the site served the homepage successfully.
- Captured a smoke-test screenshot of `/` using Playwright which shows the new `Servicios` CTA (artifact `artifacts/home-servicios-cta.png`) and the run completed successfully.
- Verified the change was committed and `git status` reports `src/pages/index.astro` as the modified file.
- No unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603c2edd748322898762cfd0c1f658)