### PR TITLE
Add global footer with social links

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -245,6 +245,50 @@ body.page-plugins .cta:hover    { background: #cef3ec; }
 .text-bold   { font-weight: 700 !important; }
 .italic      { font-style: italic !important; }
 
+/* Footer */
+.site-footer {
+  padding: 48px 24px 56px;
+  text-align: center;
+}
+
+.site-footer__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.site-footer__text {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.site-footer__social {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 0;
+  margin: 0;
+}
+
+.site-footer__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.site-footer__link:hover {
+  transform: translateY(-2px);
+  opacity: 0.85;
+}
+
 /* Iconos (Iconify) */
 .iconify {
   font-size: 28px;

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,44 @@
+---
+const socialLinks = [
+  {
+    label: "WordPress",
+    href: "https://profiles.wordpress.org/jjmontalban/",
+    icon: "simple-icons:wordpress",
+  },
+  {
+    label: "Behance",
+    href: "https://www.behance.net/jjmontalban",
+    icon: "simple-icons:behance",
+  },
+  {
+    label: "GitHub",
+    href: "https://github.com/jjmontalban",
+    icon: "simple-icons:github",
+  },
+  {
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/in/jjmontalban/",
+    icon: "simple-icons:linkedin",
+  },
+  {
+    label: "Twitter",
+    href: "https://x.com/jjmontalban",
+    icon: "simple-icons:twitter",
+  },
+];
+---
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <p class="site-footer__text">Conecta conmigo en mis perfiles profesionales</p>
+    <ul class="site-footer__social" aria-label="Perfiles sociales">
+      {socialLinks.map((link) => (
+        <li>
+          <a class="site-footer__link" href={link.href} aria-label={link.label} rel="me">
+            <iconify-icon icon={link.icon} aria-hidden="true" />
+          </a>
+        </li>
+      ))}
+    </ul>
+  </div>
+</footer>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import Navbar from "../components/Navbar.astro";
+import Footer from "../components/Footer.astro";
 
 interface Props {
   title:string;
@@ -81,6 +82,8 @@ const canonicalUrl = canonical.replace(/\/$/, "") + currentPath;
     <main class="main">
       <slot />
     </main>
+
+    <Footer />
 
     <script>
       document.documentElement.classList.remove("page-enter");


### PR DESCRIPTION
### Motivation
- Add a reusable site-wide footer that shows a short centered message and links to professional profiles using existing icons.

### Description
- Create `src/components/Footer.astro` which renders WordPress, Behance, GitHub, LinkedIn and Twitter links using `iconify-icon` with Simple Icons identifiers.
- Render the footer on every page by importing and adding `<Footer />` to `src/layouts/Layout.astro`.
- Add footer styling to `public/assets/styles.css` (`.site-footer`, `.site-footer__social`, `.site-footer__link`, etc.) to center content and style the icon list.
- Social links include `rel="me"` and accessible labels for each profile.

### Testing
- Started the dev server with `npm run dev`, which served the site successfully.
- Captured a full-page screenshot with Playwright (`artifacts/footer-home.png`) to visually verify the footer, and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69635bd94a108322979c772495191f1e)