### PR TITLE
Centralize icon definitions into a dedicated library module

### DIFF
--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,0 +1,18 @@
+import { getIconData, iconToSVG } from "@iconify/utils";
+import { icons as simpleIcons } from "@iconify-json/simple-icons";
+
+/* ========================================================= */
+/* ICONOS CENTRALIZADOS                                      */
+/* ========================================================= */
+
+export const wordpress = iconToSVG(getIconData(simpleIcons, "wordpress"), { width: 24 });
+export const github = iconToSVG(getIconData(simpleIcons, "github"), { width: 24 });
+export const php = iconToSVG(getIconData(simpleIcons, "php"), { width: 24 });
+export const mysql = iconToSVG(getIconData(simpleIcons, "mysql"), { width: 24 });
+export const javascript = iconToSVG(getIconData(simpleIcons, "javascript"), { width: 24 });
+export const woocommerce = iconToSVG(getIconData(simpleIcons, "woocommerce"), { width: 24 });
+export const mailchimp = iconToSVG(getIconData(simpleIcons, "mailchimp"), { width: 24 });
+export const googlecalendar = iconToSVG(getIconData(simpleIcons, "googlecalendar"), { width: 24 });
+export const extensions = iconToSVG(getIconData(simpleIcons, "visualstudiocode"), { width: 24 });
+export const integrations = iconToSVG(getIconData(simpleIcons, "zapier"), { width: 24 });
+export const performance = iconToSVG(getIconData(simpleIcons, "speedtest"), { width: 24 });

--- a/src/pages/casos.astro
+++ b/src/pages/casos.astro
@@ -2,21 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import ContactCTA from "../components/ContactCTA.astro";
 import { getCollection } from "astro:content";
-
-import { getIconData, iconToSVG } from "@iconify/utils";
-import { icons as simpleIcons } from "@iconify-json/simple-icons";
-
-/* ========================================================= */
-/* ICONS                                                     */
-/* ========================================================= */
-
-const wordpress = iconToSVG(getIconData(simpleIcons, "wordpress"), { width:24 });
-const php = iconToSVG(getIconData(simpleIcons, "php"), { width:24 });
-const mysql = iconToSVG(getIconData(simpleIcons, "mysql"), { width:24 });
-const javascript = iconToSVG(getIconData(simpleIcons, "javascript"), { width:24 });
-const woocommerce = iconToSVG(getIconData(simpleIcons, "woocommerce"), { width:24 });
-const mailchimp = iconToSVG(getIconData(simpleIcons, "mailchimp"), { width:24 });
-const googlecalendar = iconToSVG(getIconData(simpleIcons, "googlecalendar"), { width:24 });
+import { wordpress, php, mysql, javascript, woocommerce, mailchimp, googlecalendar } from "../lib/icons";
 
 /* ========================================================= */
 /* CONTENT                                                   */

--- a/src/pages/plugins.astro
+++ b/src/pages/plugins.astro
@@ -1,14 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import ContactCTA from "../components/ContactCTA.astro";
-
-import { getIconData, iconToSVG } from "@iconify/utils";
-import { icons as simpleIcons } from "@iconify-json/simple-icons";
-/* ========================================================= */
-/* ICONS                                                     */
-/* ========================================================= */
-const wordpress = iconToSVG(getIconData(simpleIcons, "wordpress"), { width:24 });
-const github = iconToSVG(getIconData(simpleIcons, "github"), { width:24 });
+import { wordpress, github } from "../lib/icons";
 
 const plugins = [
   {

--- a/src/pages/servicios.astro
+++ b/src/pages/servicios.astro
@@ -1,14 +1,7 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import ContactCTA from "../components/ContactCTA.astro";
-
-import { getIconData, iconToSVG } from "@iconify/utils";
-import { icons as simpleIcons } from "@iconify-json/simple-icons";
-
-const wordpress = iconToSVG(getIconData(simpleIcons, "wordpress"), { width:24 });
-const extensions = iconToSVG(getIconData(simpleIcons, "visualstudiocode"), { width:24 });
-const integrations = iconToSVG(getIconData(simpleIcons, "zapier"), { width:24 });
-const performance = iconToSVG(getIconData(simpleIcons, "speedtest"), { width:24 });
+import { wordpress, extensions, integrations, performance } from "../lib/icons";
 ---
 
 


### PR DESCRIPTION
## Summary
Refactored icon definitions across multiple pages into a centralized library module to improve maintainability and reduce code duplication.

## Changes
- **Created `src/lib/icons.ts`**: New centralized module that exports all icon definitions used throughout the application
  - Consolidates icon imports and configurations from `@iconify/utils` and `@iconify-json/simple-icons`
  - Exports 10 pre-configured icons (wordpress, github, php, mysql, javascript, woocommerce, mailchimp, googlecalendar, extensions, integrations, performance)
  - All icons standardized to 24px width

- **Updated `src/pages/casos.astro`**: Removed inline icon definitions and imported from centralized library
- **Updated `src/pages/plugins.astro`**: Removed inline icon definitions and imported from centralized library
- **Updated `src/pages/servicios.astro`**: Removed inline icon definitions and imported from centralized library

## Benefits
- **DRY principle**: Eliminates duplicate icon configuration code across multiple pages
- **Single source of truth**: Icon definitions are now managed in one location, making updates easier
- **Improved maintainability**: Future icon additions or modifications only need to be done in one place
- **Consistent styling**: Ensures all icons use the same configuration across the application